### PR TITLE
fix: remove python test assets from JS lib

### DIFF
--- a/npmignore
+++ b/npmignore
@@ -1,0 +1,1 @@
+test/pythonml/


### PR DESCRIPTION
Including previous releases prior to introducing automated publishing, it looks like we include `test/pythonml/*pkl` files in the JS package. This should fix that and reduce the size of the JS package from ~18MB to ~250kB.